### PR TITLE
Slack files.upload API廃止に伴う新APIへの乗り換え

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function takePhoto() {
   return toBlob(photo.toDataURL("image/jpeg"));
 }
 
-function notifyToSlack(message, photoBlob) {
+function notifyToSlack1(message, photoBlob) {
   const token = location.hash.substring(1);
   const formData = new FormData();
   formData.append("token", token);
@@ -49,6 +49,49 @@ function notifyToSlack(message, photoBlob) {
     method: "POST",
     body: formData
   });
+}
+
+async function notifyToSlack(message, photoBlob) {
+  const token = location.hash.substring(1);
+  const formData = new FormData();
+  formData.append("token", token);
+  formData.append("filename", "photo.jpg");
+  formData.append("length", photoBlob.size);
+
+  const r = await fetch("https://slack.com/api/files.getUploadURLExternal", {
+    method: "POST",
+    body: formData
+  });
+  const j = await r.json();
+
+  const formData2 = new FormData();
+  formData2.append("token", token);
+  formData2.append("filename", "photo.jpg");
+  formData2.append("file", photoBlob);
+
+  console.log("GO2");
+  const r2 = await fetch(j.upload_url, {
+    method: "POST",
+    body: formData2,
+    mode: 'no-cors'
+  });
+  console.log(r2);
+  //const j2 = await r2.json();
+  //console.log(j2);
+
+  const formData3 = new FormData();
+  formData3.append("token", token);
+  formData3.append("files", JSON.stringify([{"id":j.file_id}]));
+  formData3.append("channel_id", "GJ7SH8L5T");
+  formData3.append("initial_comment", message);
+
+  const r3 = await fetch("https://slack.com/api/files.completeUploadExternal", {
+    method: "POST",
+    body: formData3
+  });
+  console.log(r3);
+  const j3 = await r3.json();
+  console.log(j3);
 }
 
 async function ring(soundId, message) {

--- a/index.js
+++ b/index.js
@@ -36,21 +36,6 @@ function takePhoto() {
   return toBlob(photo.toDataURL("image/jpeg"));
 }
 
-function notifyToSlack1(message, photoBlob) {
-  const token = location.hash.substring(1);
-  const formData = new FormData();
-  formData.append("token", token);
-  formData.append("channels", "GJ7SH8L5T");
-  formData.append("file", photoBlob);
-  formData.append("filename", "photo.jpg");
-  formData.append("initial_comment", message);
-
-  fetch("https://slack.com/api/files.upload", {
-    method: "POST",
-    body: formData
-  });
-}
-
 async function notifyToSlack(message, photoBlob) {
   const token = location.hash.substring(1);
 

--- a/index.js
+++ b/index.js
@@ -43,20 +43,20 @@ async function notifyToSlack(message, photoBlob) {
   f1.append("token", token);
   f1.append("filename", "photo.jpg");
   f1.append("length", photoBlob.size);
-  const {upload_url, file_id} = await (await fetch("https://slack.com/api/files.getUploadURLExternal", {method: "POST", body: f1})).json();
+  const {upload_url, file_id} = await (await fetch("https://slack.com/api/files.getUploadURLExternal", {method:"POST", body:f1})).json();
 
   const f2 = new FormData();
   f2.append("token", token);
   f2.append("filename", "photo.jpg");
   f2.append("file", photoBlob);
-  await fetch(upload_url, {method: "POST", body: f2, mode: "no-cors"});
+  await fetch(upload_url, {method:"POST", body:f2, mode:"no-cors"});
 
   const f3 = new FormData();
   f3.append("token", token);
   f3.append("files", `[{"id":"${file_id}"}]`);
   f3.append("channel_id", "GJ7SH8L5T");
   f3.append("initial_comment", message);
-  fetch("https://slack.com/api/files.completeUploadExternal", {method: "POST", body: f3});
+  fetch("https://slack.com/api/files.completeUploadExternal", {method:"POST", body:f3});
 }
 
 async function ring(soundId, message) {

--- a/index.js
+++ b/index.js
@@ -53,45 +53,25 @@ function notifyToSlack1(message, photoBlob) {
 
 async function notifyToSlack(message, photoBlob) {
   const token = location.hash.substring(1);
-  const formData = new FormData();
-  formData.append("token", token);
-  formData.append("filename", "photo.jpg");
-  formData.append("length", photoBlob.size);
 
-  const r = await fetch("https://slack.com/api/files.getUploadURLExternal", {
-    method: "POST",
-    body: formData
-  });
-  const j = await r.json();
+  const f1 = new FormData();
+  f1.append("token", token);
+  f1.append("filename", "photo.jpg");
+  f1.append("length", photoBlob.size);
+  const {upload_url, file_id} = await (await fetch("https://slack.com/api/files.getUploadURLExternal", {method: "POST", body: f1})).json();
 
-  const formData2 = new FormData();
-  formData2.append("token", token);
-  formData2.append("filename", "photo.jpg");
-  formData2.append("file", photoBlob);
+  const f2 = new FormData();
+  f2.append("token", token);
+  f2.append("filename", "photo.jpg");
+  f2.append("file", photoBlob);
+  await fetch(upload_url, {method: "POST", body: f2, mode: "no-cors"});
 
-  console.log("GO2");
-  const r2 = await fetch(j.upload_url, {
-    method: "POST",
-    body: formData2,
-    mode: 'no-cors'
-  });
-  console.log(r2);
-  //const j2 = await r2.json();
-  //console.log(j2);
-
-  const formData3 = new FormData();
-  formData3.append("token", token);
-  formData3.append("files", JSON.stringify([{"id":j.file_id}]));
-  formData3.append("channel_id", "GJ7SH8L5T");
-  formData3.append("initial_comment", message);
-
-  const r3 = await fetch("https://slack.com/api/files.completeUploadExternal", {
-    method: "POST",
-    body: formData3
-  });
-  console.log(r3);
-  const j3 = await r3.json();
-  console.log(j3);
+  const f3 = new FormData();
+  f3.append("token", token);
+  f3.append("files", `[{"id":"${file_id}"}]`);
+  f3.append("channel_id", "GJ7SH8L5T");
+  f3.append("initial_comment", message);
+  fetch("https://slack.com/api/files.completeUploadExternal", {method: "POST", body: f3});
 }
 
 async function ring(soundId, message) {


### PR DESCRIPTION
1回のWeb API呼び出しが3回に分かれている。
ドキュメントには記載ないが特にFormDataのままでも良いようなのでそのままとした。

2 step目のAPIは"Access-Control-Allow-Origin: *"がなく、ブラウザに止められる。
"no-cors"で無理やり回避。
エラー処理適当ゆえ、戻り値を見る必要もないのでこれでなんとかなる。

旧実装と同様になげっぱなし設計ゆえ、3 step目の戻りも待たない。